### PR TITLE
Make it work on GNUstep

### DIFF
--- a/SMJJSONPath/Internals/SMJArrayIndexOperation.m
+++ b/SMJJSONPath/Internals/SMJArrayIndexOperation.m
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 		NSScanner *scanner = [NSScanner scannerWithString:[token stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]]];
 		NSInteger index = 0;
 		
-		if ([scanner scanInteger:&index] && scanner.atEnd)
+		if ([scanner scanInteger:&index] && scanner.isAtEnd)
 			[tempIndexes addObject:@(index)];
 		else
 		{

--- a/SMJJSONPath/Internals/SMJCharacterIndex.h
+++ b/SMJJSONPath/Internals/SMJCharacterIndex.h
@@ -21,6 +21,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <CoreFoundation/CFBase.h>
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/SMJJSONPath/Internals/SMJEvaluatorFactory.h
+++ b/SMJJSONPath/Internals/SMJEvaluatorFactory.h
@@ -21,6 +21,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
 
 #import "SMJEvaluator.h"
 #import "SMJRelationalOperator.h"

--- a/SMJJSONPath/Internals/SMJLogicalOperator.h
+++ b/SMJJSONPath/Internals/SMJLogicalOperator.h
@@ -21,6 +21,8 @@
 
 
 #import <Foundation/Foundation.h>
+#import <CoreFoundation/CFString.h>
+#import <dispatch/dispatch.h>
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/SMJJSONPath/Internals/SMJPathRef.h
+++ b/SMJJSONPath/Internals/SMJPathRef.h
@@ -21,6 +21,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
 
 #import "SMJConfiguration.h"
 

--- a/SMJJSONPath/Internals/SMJRelationalOperator.h
+++ b/SMJJSONPath/Internals/SMJRelationalOperator.h
@@ -21,6 +21,8 @@
 
 
 #import <Foundation/Foundation.h>
+#import <CoreFoundation/CFString.h>
+#import <dispatch/dispatch.h>
 
 
 NS_ASSUME_NONNULL_BEGIN

--- a/SMJJSONPath/Internals/SMJUtils.m
+++ b/SMJJSONPath/Internals/SMJUtils.m
@@ -286,7 +286,9 @@ static NSString * hexadecimal(uint16_t value);
 + (nullable NSNumber *)numberWithString:(NSString *)string
 {
 	NSScanner *scanner;
- 
+
+#if TARGET_OS_OSX // scanUnsignedLongLong is not available in GNUstep yet
+
 	// Test unsigned long long int.
 	unsigned long long unsignedLongLong = 0;
 
@@ -294,10 +296,11 @@ static NSString * hexadecimal(uint16_t value);
 	
 	scanner.charactersToBeSkipped = [NSCharacterSet whitespaceCharacterSet];
 	
-	if ([scanner scanUnsignedLongLong:&unsignedLongLong] && scanner.atEnd)
+	if ([scanner scanUnsignedLongLong:&unsignedLongLong] && scanner.isAtEnd)
 		return @(unsignedLongLong);
-	
-	
+
+#endif /* TARGET_OS_OSX */
+
 	// Test signed long long int.
 	long long signedLongLong = 0;
 	
@@ -305,7 +308,7 @@ static NSString * hexadecimal(uint16_t value);
 
 	scanner.charactersToBeSkipped = [NSCharacterSet whitespaceCharacterSet];
 
-	if ([scanner scanLongLong:&signedLongLong] && scanner.atEnd)
+	if ([scanner scanLongLong:&signedLongLong] && scanner.isAtEnd)
 		return @(signedLongLong);
 
 	
@@ -317,7 +320,7 @@ static NSString * hexadecimal(uint16_t value);
 	scanner.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
 	scanner.charactersToBeSkipped = [NSCharacterSet whitespaceCharacterSet];
 	
-	if ([scanner scanDouble:&doubleValue] && scanner.atEnd)
+	if ([scanner scanDouble:&doubleValue] && scanner.isAtEnd)
 		return @(doubleValue);
 	
 	return nil;

--- a/SMJJSONPath/Internals/SMJValueNodes.h
+++ b/SMJJSONPath/Internals/SMJValueNodes.h
@@ -21,6 +21,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
 
 #import "SMJValueNode.h"
 

--- a/SMJJSONPath/SMJPathFunctionFactory.h
+++ b/SMJJSONPath/SMJPathFunctionFactory.h
@@ -21,6 +21,7 @@
 
 
 #import <Foundation/Foundation.h>
+#import <dispatch/dispatch.h>
 
 #import "SMJPathFunction.h"
 


### PR DESCRIPTION
I followed https://github.com/plaurent/gnustep-build/blob/master/ubuntu-19.10-clang-9.0-runtime-2.0/GNUstep-buildon-ubuntu1910.sh and other guides to compile this under Ubuntu with GNUstep.

Below are necessary changes I had to make to get it to compile. Mostly it is includes, at one point I had to disable a specific call because the interface doesn't exist on GNUstep (yet).

Please review those changes, as I have next to no understanding of Objective C or related libraries.

If you are interested in reproducing these results under Ubuntu, I'm happy to provide a Dockerfile that provides that environment. (Currently the files reside under https://github.com/cburgmer/json-path-comparison/blob/Objective-C_SMJJSONPath/src/installObjectiveC.sh and https://github.com/cburgmer/json-path-comparison/blob/Objective-C_SMJJSONPath/implementations/Objective-C_SMJJSONPath/compile.sh.)